### PR TITLE
Set marker command in mission file

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "Mission Control"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.0
+PROJECT_NUMBER         = 1.1.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mission Control
 
+Version: `2.0.0`
+
 The Mission Control node is responsible for the main mission logic.
 It gathers all required information from the different nodes and chooses the next action.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mission Control
 
-Version: `2.0.0`
+Version: `1.1.0`
 
 The Mission Control node is responsible for the main mission logic.
 It gathers all required information from the different nodes and chooses the next action.

--- a/include/mission_control.hpp
+++ b/include/mission_control.hpp
@@ -57,6 +57,7 @@ class MissionControl : public common_lib::CommonNode {
         decision_maker,
         fly_to_waypoint,
         detect_marker,
+        set_marker,
     } MissionState_t;
 
     // General
@@ -290,6 +291,7 @@ class MissionControl : public common_lib::CommonNode {
     virtual void mode_decision_maker();
     virtual void mode_fly_to_waypoint();
     virtual void mode_detect_marker();
+    virtual void mode_set_marker();
 
     // Job finished
     void job_finished_callback(const interfaces::msg::JobFinished &msg);

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mission_control_package</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Package for the Mission Control node</description>
   <maintainer email="phg6386@thi.de">philipp</maintainer>
   <license>MIT</license>

--- a/src/basics.cpp
+++ b/src/basics.cpp
@@ -302,6 +302,7 @@ const char* MissionControl::get_mission_state_str(
         ENUM_TO_STR(decision_maker);
         ENUM_TO_STR(fly_to_waypoint);
         ENUM_TO_STR(detect_marker);
+        ENUM_TO_STR(set_marker);
         default:
             throw std::runtime_error(
                 "MissionControl::" + (std::string) __func__ +

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -483,6 +483,12 @@ void MissionControl::heartbeat_timer_callback() {
                 "'" +
                 get_mission_state_str(selfcheck) + "' or '" +
                 get_mission_state_str(prepare_mission) + "' state");
+        } else {
+            RCLCPP_DEBUG(this->get_logger(),
+                         "MissionControl::%s: Missing heartbeat or FCC bridge "
+                         "not active while in '%s' state. Ignoring this fact "
+                         "in this state.",
+                         __func__, get_mission_state_str());
         }
     }
 }

--- a/src/mission_control.cpp
+++ b/src/mission_control.cpp
@@ -175,6 +175,9 @@ void MissionControl::event_loop() {
         case detect_marker:
             mode_detect_marker();
             break;
+        case set_marker:
+            mode_set_marker();
+            break;
         default:
             RCLCPP_ERROR(this->get_logger(),
                          "MissionControl::%s: Unknown mission_state: %d",

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -477,6 +477,8 @@ void MissionControl::mode_decision_maker() {
         set_mission_state(fly_to_waypoint);
     else if (current_command_type == "detect_marker")
         set_mission_state(detect_marker);
+    else if (current_command_type == "set_marker")
+        set_mission_state(set_marker);
     else if (current_command_type == "end_mission")
         mission_finished();
     else
@@ -650,4 +652,29 @@ void MissionControl::mode_detect_marker() {
                     __func__, get_mission_state_str(decision_maker));
         set_mission_state(decision_maker);
     }
+}
+
+/**
+ * @brief Sets the active marker
+ *
+ * It retrieves the new marker name from the current command and sets it as the
+ * active marker.
+ */
+void MissionControl::mode_set_marker() {
+    // Deactivate Event Loop as it is not needed for set marker
+    EventLoopGuard elg(&event_loop_active, false);
+
+    // Set new active marker
+    const std::string new_marker_name = commands.at(current_command_id)
+                                            .data.at("marker_name")
+                                            .get<std::string>();
+    set_active_marker_name(new_marker_name);
+
+    // Set mission state to 'decision_maker'
+    RCLCPP_INFO(this->get_logger(),
+                "MissionControl::%s: New marker name '%s' set. Set mission "
+                "state to '%s'.",
+                __func__, get_active_marker_name().c_str(),
+                get_mission_state_str(decision_maker));
+    set_mission_state(decision_maker);
 }

--- a/test/basics_test.cpp
+++ b/test/basics_test.cpp
@@ -858,6 +858,8 @@ TEST(mission_control_package, get_mission_state_str_test) {
                      "fly_to_waypoint");
         ASSERT_STREQ(mc.get_mission_state_str(MissionControl::detect_marker),
                      "detect_marker");
+        ASSERT_STREQ(mc.get_mission_state_str(MissionControl::set_marker),
+                     "set_marker");
     }
 
     // Test with invalid mission state

--- a/test/callbacks_test.cpp
+++ b/test/callbacks_test.cpp
@@ -1530,6 +1530,14 @@ executor.spin();
 }
 }
 
+/**
+ * @brief Test case for the `heartbeat_timer_callback` function in the
+ * `mission_control_package`.
+ *
+ * This test case verifies the behavior of the `heartbeat_timer_callback`
+ * function in the `mission_control_package`. It tests various scenarios related
+ * to heartbeat reception and mission state.
+ */
 TEST(mission_control_package, heartbeat_timer_callback_test) {
     rclcpp::NodeOptions default_options;
     default_options.append_parameter_override(

--- a/test/mission_control_test.cpp
+++ b/test/mission_control_test.cpp
@@ -540,6 +540,7 @@ TEST(mission_control_package, event_loop_test) {
         size_t mode_decision_maker_counter = 0;
         size_t mode_fly_to_waypoint_counter = 0;
         size_t mode_detect_marker_counter = 0;
+        size_t mode_set_marker_counter = 0;
 
        public:
         CustomMissionControl(
@@ -594,6 +595,13 @@ TEST(mission_control_package, event_loop_test) {
 
             mode_detect_marker_counter++;
         }
+
+        void mode_set_marker() override {
+            RCLCPP_DEBUG(this->get_logger(), "Custom function '%s' called",
+                         __func__);
+
+            mode_set_marker_counter++;
+        }
     };
 
     // Check state 'prepare_mission'
@@ -633,6 +641,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_fly_to_waypoint_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -677,6 +686,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_fly_to_waypoint_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -722,6 +732,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_fly_to_waypoint_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -764,6 +775,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_fly_to_waypoint_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -807,6 +819,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_fly_to_waypoint_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -851,6 +864,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_fly_to_waypoint_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -896,6 +910,7 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_decision_maker_counter);
                     ASSERT_EQ(0,
                               mission_control_node->mode_detect_marker_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
 
                     executor.cancel();
                 });
@@ -939,6 +954,52 @@ TEST(mission_control_package, event_loop_test) {
                         0, mission_control_node->mode_decision_maker_counter);
                     ASSERT_EQ(
                         0, mission_control_node->mode_fly_to_waypoint_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_set_marker_counter);
+
+                    executor.cancel();
+                });
+
+        executor.add_node(mission_control_node);
+        executor.spin();
+    }
+
+    // Check state 'set_marker'
+    {
+        rclcpp::executors::SingleThreadedExecutor executor;
+
+        std::shared_ptr<CustomMissionControl> mission_control_node =
+            std::make_shared<CustomMissionControl>(default_options);
+
+        mission_control_node->set_mission_state(MissionControl::set_marker);
+
+        const uint32_t timer_executions = 5;
+
+        rclcpp::TimerBase::SharedPtr end_timer =
+            mission_control_node->create_wall_timer(
+                std::chrono::milliseconds(
+                    mission_control_node->event_loop_time_delta_ms *
+                    timer_executions),
+                [mission_control_node, &executor, timer_executions]() {
+                    RCLCPP_DEBUG(mission_control_node->get_logger(),
+                                 "Ending event loop test");
+
+                    // Check that counts are correct
+                    ASSERT_EQ(timer_executions,
+                              mission_control_node->mode_set_marker_counter);
+
+                    ASSERT_EQ(
+                        0, mission_control_node->mode_prepare_mission_counter);
+                    ASSERT_EQ(0, mission_control_node->mode_self_check_counter);
+                    ASSERT_EQ(0, mission_control_node
+                                     ->mode_check_drone_configuration_counter);
+                    ASSERT_EQ(0,
+                              mission_control_node->initiate_takeoff_counter);
+                    ASSERT_EQ(
+                        0, mission_control_node->mode_decision_maker_counter);
+                    ASSERT_EQ(
+                        0, mission_control_node->mode_fly_to_waypoint_counter);
+                    ASSERT_EQ(0,
+                              mission_control_node->mode_detect_marker_counter);
 
                     executor.cancel();
                 });

--- a/test/mission_file_reader/mission_file_reader_test.cpp
+++ b/test/mission_file_reader/mission_file_reader_test.cpp
@@ -242,27 +242,17 @@ TEST(mission_control_package, file_format_test) {
                                    true),
                      std::runtime_error);
     }
-}
 
-/**
- * @brief Test case for the mission_control_package.
- *
- * This test case verifies the behavior of the `set_marker_test` function.
- * It tests various scenarios with different JSON files to ensure that the
- * `MissionDefinitionReader` correctly handles the "set_marker" command in a
- * marker.
- */
-TEST(mission_control_package, set_marker_test) {
-    // {
-    //     // Test correct json file with "set_marker" command in a
-    //     // marker
-    //     MissionDefinitionReader mdr;
-    //     ASSERT_NO_THROW(
-    //         mdr.read_file("../../src/mission_control_package/test/"
-    //                       "mission_file_reader/test_assets/"
-    //                       "mdf_correct_set_marker.json",
-    //                       true));
-    // }
+    {
+        // Test correct json file with "set_marker" command in a
+        // marker
+        MissionDefinitionReader mdr;
+        ASSERT_NO_THROW(
+            mdr.read_file("../../src/mission_control_package/test/"
+                          "mission_file_reader/test_assets/"
+                          "mdf_correct_set_marker.json",
+                          true));
+    }
 
     {
         // Test incorrect json file with "set_marker" before a "end_mission"

--- a/test/mission_file_reader/mission_file_reader_test.cpp
+++ b/test/mission_file_reader/mission_file_reader_test.cpp
@@ -231,6 +231,71 @@ TEST(mission_control_package, file_format_test) {
                                    true),
                      std::runtime_error);
     }
+
+    {
+        // Test incorrect json file with "detect_marker" before a "end_mission"
+        // command in a marker
+        MissionDefinitionReader mdr;
+        ASSERT_THROW(mdr.read_file("../../src/mission_control_package/test/"
+                                   "mission_file_reader/test_assets/"
+                                   "mdf_incorrect_detect_marker.json",
+                                   true),
+                     std::runtime_error);
+    }
+
+    {
+        // Test correct json file with "set_marker" command in a
+        // marker
+        MissionDefinitionReader mdr;
+        ASSERT_NO_THROW(
+            mdr.read_file("../../src/mission_control_package/test/"
+                          "mission_file_reader/test_assets/"
+                          "mdf_correct_set_marker.json",
+                          true));
+    }
+
+    {
+        // Test incorrect json file with "set_marker" before a "end_mission"
+        // command in a marker
+        MissionDefinitionReader mdr;
+        ASSERT_THROW(mdr.read_file("../../src/mission_control_package/test/"
+                                   "mission_file_reader/test_assets/"
+                                   "mdf_incorrect_set_marker.json",
+                                   true),
+                     std::runtime_error);
+    }
+
+    {
+        // Test incorrect json file with "set_marker" and "detect_marker"
+        // commands in a marker
+        MissionDefinitionReader mdr;
+        ASSERT_THROW(mdr.read_file("../../src/mission_control_package/test/"
+                                   "mission_file_reader/test_assets/"
+                                   "mdf_incorrect_set_marker_2.json",
+                                   true),
+                     std::runtime_error);
+    }
+
+    {
+        // Test incorrect json file with "detect_marker" and "set_marker"
+        // commands in a marker
+        MissionDefinitionReader mdr;
+        ASSERT_THROW(mdr.read_file("../../src/mission_control_package/test/"
+                                   "mission_file_reader/test_assets/"
+                                   "mdf_incorrect_set_marker_3.json",
+                                   true),
+                     std::runtime_error);
+    }
+
+    {
+        // Test incorrect json file with invalid marker name in "set_marker"
+        MissionDefinitionReader mdr;
+        ASSERT_THROW(mdr.read_file("../../src/mission_control_package/test/"
+                                   "mission_file_reader/test_assets/"
+                                   "mdf_incorrect_set_marker_4.json",
+                                   true),
+                     std::runtime_error);
+    }
 }
 
 /**

--- a/test/mission_file_reader/mission_file_reader_test.cpp
+++ b/test/mission_file_reader/mission_file_reader_test.cpp
@@ -296,6 +296,17 @@ TEST(mission_control_package, file_format_test) {
                                    true),
                      std::runtime_error);
     }
+
+    {
+        // Test incorrect json file with two "set_marker" commands in a
+        // marker
+        MissionDefinitionReader mdr;
+        ASSERT_THROW(mdr.read_file("../../src/mission_control_package/test/"
+                                   "mission_file_reader/test_assets/"
+                                   "mdf_too_many_set_marker.json",
+                                   true),
+                     std::runtime_error);
+    }
 }
 
 /**

--- a/test/mission_file_reader/mission_file_reader_test.cpp
+++ b/test/mission_file_reader/mission_file_reader_test.cpp
@@ -253,16 +253,16 @@ TEST(mission_control_package, file_format_test) {
  * marker.
  */
 TEST(mission_control_package, set_marker_test) {
-    {
-        // Test correct json file with "set_marker" command in a
-        // marker
-        MissionDefinitionReader mdr;
-        ASSERT_NO_THROW(
-            mdr.read_file("../../src/mission_control_package/test/"
-                          "mission_file_reader/test_assets/"
-                          "mdf_correct_set_marker.json",
-                          true));
-    }
+    // {
+    //     // Test correct json file with "set_marker" command in a
+    //     // marker
+    //     MissionDefinitionReader mdr;
+    //     ASSERT_NO_THROW(
+    //         mdr.read_file("../../src/mission_control_package/test/"
+    //                       "mission_file_reader/test_assets/"
+    //                       "mdf_correct_set_marker.json",
+    //                       true));
+    // }
 
     {
         // Test incorrect json file with "set_marker" before a "end_mission"

--- a/test/mission_file_reader/mission_file_reader_test.cpp
+++ b/test/mission_file_reader/mission_file_reader_test.cpp
@@ -242,7 +242,9 @@ TEST(mission_control_package, file_format_test) {
                                    true),
                      std::runtime_error);
     }
+}
 
+TEST(mission_control_package, set_marker_test) {
     {
         // Test correct json file with "set_marker" command in a
         // marker

--- a/test/mission_file_reader/test_assets/mdf_correct_set_marker.json
+++ b/test/mission_file_reader/test_assets/mdf_correct_set_marker.json
@@ -1,0 +1,90 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "1"
+            }
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}

--- a/test/mission_file_reader/test_assets/mdf_incorrect_detect_marker.json
+++ b/test/mission_file_reader/test_assets/mdf_incorrect_detect_marker.json
@@ -55,7 +55,7 @@
          {
             "type": "detect_marker",
             "data": {
-               "marker_name": "1"
+               "timeout_ms": 30000
             }
          },
          {

--- a/test/mission_file_reader/test_assets/mdf_incorrect_detect_marker.json
+++ b/test/mission_file_reader/test_assets/mdf_incorrect_detect_marker.json
@@ -1,0 +1,94 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "marker_name": "1"
+            }
+         },
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}

--- a/test/mission_file_reader/test_assets/mdf_incorrect_set_marker.json
+++ b/test/mission_file_reader/test_assets/mdf_incorrect_set_marker.json
@@ -1,0 +1,94 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "1"
+            }
+         },
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}

--- a/test/mission_file_reader/test_assets/mdf_incorrect_set_marker_2.json
+++ b/test/mission_file_reader/test_assets/mdf_incorrect_set_marker_2.json
@@ -1,0 +1,96 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "1"
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}

--- a/test/mission_file_reader/test_assets/mdf_incorrect_set_marker_3.json
+++ b/test/mission_file_reader/test_assets/mdf_incorrect_set_marker_3.json
@@ -1,0 +1,96 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "1"
+            }
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}

--- a/test/mission_file_reader/test_assets/mdf_incorrect_set_marker_4.json
+++ b/test/mission_file_reader/test_assets/mdf_incorrect_set_marker_4.json
@@ -1,0 +1,90 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "a"
+            }
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}

--- a/test/mission_file_reader/test_assets/mdf_too_many_set_marker.json
+++ b/test/mission_file_reader/test_assets/mdf_too_many_set_marker.json
@@ -1,0 +1,96 @@
+{
+   "safety": {
+      "geofence": [
+         {
+            "lat": 48.768466,
+            "lon": 11.336380
+         },
+         {
+            "lat": 48.768175,
+            "lon": 11.337411
+         },
+         {
+            "lat": 48.768187,
+            "lon": 11.336225
+         },
+         {
+            "lat": 48.767764,
+            "lon": 11.337214
+         }
+      ],
+      "max_height_cm": 5000,
+      "min_cruise_height_cm": 500,
+      "max_horizontal_speed_mps": 10.0,
+      "max_vertical_speed_mps": 2.5,
+      "min_soc_percent": 30
+   },
+   "markers": {
+      "init": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768158,
+               "target_coordinate_lon": 11.336879,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 100,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768175,
+               "target_coordinate_lon": 11.336760,
+               "pre_wait_time_ms": 100,
+               "post_wait_time_ms": 200,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "detect_marker",
+            "data": {
+               "timeout_ms": 30000
+            }
+         }
+      ],
+      "1": [
+         {
+            "type": "waypoint",
+            "data": {
+               "target_coordinate_lat": 48.768004,
+               "target_coordinate_lon": 11.337075,
+               "pre_wait_time_ms": 0,
+               "post_wait_time_ms": 0,
+               "cruise_height_cm": 2000,
+               "target_height_cm": 500,
+               "horizontal_speed_mps": 3.0,
+               "vertical_speed_mps": 1.0
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "2"
+            }
+         },
+         {
+            "type": "set_marker",
+            "data": {
+               "marker_name": "2"
+            }
+         }
+      ],
+      "2": [
+         {
+            "type": "end_mission",
+            "data": {}
+         }
+      ]
+   }
+}


### PR DESCRIPTION
This PR introduces a new command in the MDF:
The `set_marker` command basically skips the QR code scanning and directly sets a new marker as if it was detected.
This allows for easier and faster adaptions if the qr code scanning fails, as we need to adapt our files in this case.
This way, we can simply replace `detect_marker` with `set_marker`.

Additionally, the unit tests are now complete.